### PR TITLE
update heroku link with node server endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Make sure you have [Heroky CLI](https://devcenter.heroku.com/articles/heroku-cli
 
 - `git push heroku master` - push changes to Heroku and trigger deploying
 
-- Now you have to configure frame app to use the URL provided by Heroku like `https://<APP-NAME>.herokuapp.com/topcoder-micro-frontends-earn-app.js` to load this microapp.
+- Now you have to configure frame app to use the URL provided by Heroku like `https://<APP-NAME>.herokuapp.com/earn-app/topcoder-micro-frontends-earn-app.js` to load this microapp.
 


### PR DESCRIPTION
I struggle half hour to understand that I need to go to earn-app endpoint to access topcoder-micro-frontends-earn-app.js file
https://.herokuapp.com/earn-app/topcoder-micro-frontends-earn-app.js is right url